### PR TITLE
Resolves gh-10: Adds support for ASIO

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     env:
-      CPAL_ASIO_DIR: "$Env:GITHUB_WORKSPACE\asio"
+      CPAL_ASIO_DIR: "$Env:GITHUB_WORKSPACE\\asio"
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -51,6 +51,8 @@ jobs:
           command: build
 
       - name: run print_audio_tree example
+        env:
+          RUST_BACKTRACE: 1
         uses: actions-rs/cargo@v1
         with:
           command: run

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     env:
-      CPAL_ASIO_DIR: "$Env:GITHUB_WORKSPACE\\asio"
+      CPAL_ASIO_DIR: "${{env.GITHUB_WORKSPACE}}\\asio"
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     env:
-      CPAL_ASIO_DIR: "%GITHUB_WORKSPACE%\\asio"
+      CPAL_ASIO_DIR: ${{ env.GITHUB_WORKSPACE }}/asio
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,6 +11,9 @@ jobs:
 
     runs-on: ${{ matrix.os }}
 
+    env:
+      CPAL_ASIO_DIR: "$Env:GITHUB_WORKSPACE\asio"
+
     steps:
       - uses: actions/checkout@v2
 
@@ -23,6 +26,7 @@ jobs:
         run: sudo apt-get install libasound2-dev
 
       - name: Install Widows ASIO SDK
+        if: runner.os == 'Windows'
         env:
           LINK: https://www.steinberg.net/asiosdk
         run: |
@@ -30,7 +34,6 @@ jobs:
           7z x -oasio asio.zip
           move asio\*\* asio\
           choco install asio4all llvm
-          $Env:CPAL_ASIO_DIR = "$Env:GITHUB_WORKSPACE\asio"
 
       - name: cargo check
         uses: actions-rs/cargo@v1

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,6 +22,16 @@ jobs:
         if: runner.os == 'Linux'
         run: sudo apt-get install libasound2-dev
 
+      - name: Install Widows ASIO SDK
+        env:
+          LINK: https://www.steinberg.net/asiosdk
+        run: |
+          curl -L -o asio.zip $env:LINK
+          7z x -oasio asio.zip
+          move asio\*\* asio\
+          choco install asio4all llvm
+          $Env:CPAL_ASIO_DIR = "$Env:GITHUB_WORKSPACE\asio"
+
       - name: cargo check
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     env:
-      CPAL_ASIO_DIR: "${{env.GITHUB_WORKSPACE}}\\asio"
+      CPAL_ASIO_DIR: "${{GITHUB_WORKSPACE}}\\asio"
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     env:
-      CPAL_ASIO_DIR: "${{GITHUB_WORKSPACE}}\\asio"
+      CPAL_ASIO_DIR: "%GITHUB_WORKSPACE%\\asio"
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     env:
-      CPAL_ASIO_DIR: ${{ env.GITHUB_WORKSPACE }}/asio
+      CPAL_ASIO_DIR: ${{ github.workspace }}/asio
 
     steps:
       - uses: actions/checkout@v2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,6 +22,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7404febffaa47dac81aa44dba71523c9d069b1bdc50a77db41195149e17f68e5"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "alsa"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -44,10 +53,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "ascii"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eab1c04a571841102f5345a8fc0f6bb3d31c315dec879b5c6e42e40ce7ffa34e"
+
+[[package]]
+name = "asio-sys"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47629cb63178cf13daf45db2d7256cc3fcd986d05b9070d4d1a758a2b4141bd5"
+dependencies = [
+ "bindgen 0.54.0",
+ "cc",
+ "lazy_static",
+ "num-derive",
+ "num-traits",
+ "walkdir",
+]
+
+[[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "autocfg"
@@ -83,12 +126,13 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "bindgen"
-version = "0.56.0"
+version = "0.53.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2da379dbebc0b76ef63ca68d8fc6e71c0f13e59432e0987e508c1820e6ab5239"
+checksum = "c72a978d268b1d70b0e963217e60fdabd9523a941457a6c42a7315d15c7e89e5"
 dependencies = [
  "bitflags",
  "cexpr",
+ "cfg-if 0.1.10",
  "clang-sys",
  "lazy_static",
  "lazycell",
@@ -98,6 +142,30 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66c0bb6167449588ff70803f4127f0684f9063097eca5016f37eb52b92c2cf36"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "cfg-if 0.1.10",
+ "clang-sys",
+ "clap",
+ "env_logger",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "peeking_take_while",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "which",
 ]
 
 [[package]]
@@ -165,13 +233,28 @@ checksum = "fff857943da45f546682664a79488be82e69e43c1a7a2307679ab9afb3a66d2e"
 
 [[package]]
 name = "clang-sys"
-version = "1.1.1"
+version = "0.29.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f54d78e30b388d4815220c8dd03fea5656b6c6d32adb59e89061552a102f8da1"
+checksum = "fe6837df1d5cba2397b835c8530f51723267e16abbf83892e9e5af4f0e5dd10a"
 dependencies = [
  "glob",
  "libc",
  "libloading",
+]
+
+[[package]]
+name = "clap"
+version = "2.33.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
+dependencies = [
+ "ansi_term",
+ "atty",
+ "bitflags",
+ "strsim 0.8.0",
+ "textwrap",
+ "unicode-width",
+ "vec_map",
 ]
 
 [[package]]
@@ -248,11 +331,11 @@ dependencies = [
 
 [[package]]
 name = "coreaudio-sys"
-version = "0.2.8"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b7e3347be6a09b46aba228d6608386739fb70beff4f61e07422da87b0bb31fa"
+checksum = "17f73df0f29f4c3c374854f076c47dc018f19acaa63538880dba0937ad4fa8d7"
 dependencies = [
- "bindgen",
+ "bindgen 0.53.3",
 ]
 
 [[package]]
@@ -262,6 +345,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05631e2089dfa5d3b6ea1cfbbfd092e2ee5deeb69698911bc976b28b746d3657"
 dependencies = [
  "alsa",
+ "asio-sys",
  "core-foundation-sys",
  "coreaudio-rs",
  "jni 0.17.0",
@@ -272,6 +356,7 @@ dependencies = [
  "ndk",
  "ndk-glue",
  "nix",
+ "num-traits",
  "oboe",
  "parking_lot",
  "stdweb 0.1.3",
@@ -309,7 +394,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.9.3",
  "syn",
 ]
 
@@ -346,6 +431,19 @@ name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+
+[[package]]
+name = "env_logger"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
+dependencies = [
+ "atty",
+ "humantime",
+ "log",
+ "regex",
+ "termcolor",
+]
 
 [[package]]
 name = "error-chain"
@@ -407,6 +505,24 @@ name = "glob"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "322f4de77956e22ed0e5032c359a0f1273f1f7f0d79bfa3b8ffbc730d7fbcc5c"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "humantime"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
+dependencies = [
+ "quick-error",
+]
 
 [[package]]
 name = "ident_case"
@@ -523,16 +639,17 @@ checksum = "3286f09f7d4926fc486334f28d8d2e6ebe4f7f9994494b6dab27ddfad2c9b11b"
 name = "libflock_cpal"
 version = "0.0.1"
 dependencies = [
+ "clang-sys",
  "cpal",
 ]
 
 [[package]]
 name = "libloading"
-version = "0.7.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f84d96438c15fcd6c3f244c8fce01d1e2b9c6b5623e9c711dc9286d8fc92d6a"
+checksum = "f2b111a074963af1d37a139918ac6d49ad1d0d5e47f72fd55388619691a7d753"
 dependencies = [
- "cfg-if 1.0.0",
+ "cc",
  "winapi",
 ]
 
@@ -817,6 +934,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quote"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -840,6 +963,8 @@ version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "957056ecddbeba1b26965114e191d2e8589ce74db242b6ea25fc4062427a5c19"
 dependencies = [
+ "aho-corasick",
+ "memchr",
  "regex-syntax",
 ]
 
@@ -1071,6 +1196,12 @@ checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
 
 [[package]]
 name = "strsim"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "strsim"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
@@ -1095,6 +1226,24 @@ dependencies = [
  "filetime",
  "libc",
  "xattr",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -1198,6 +1347,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-width"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1248,6 +1403,12 @@ dependencies = [
  "matches",
  "percent-encoding",
 ]
+
+[[package]]
+name = "vec_map"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
@@ -1353,6 +1514,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82015b7e0b8bad8185994674a13a93306bea76cf5a16c5a181382fd3a5ec2376"
 dependencies = [
  "webpki",
+]
+
+[[package]]
+name = "which"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d011071ae14a2f6671d0b74080ae0cd8ebf3a6f8c9589a2cd45f23126fe29724"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,7 @@ edition = "2018"
 
 [dependencies]
 cpal = "0.13.1"
+
+[target.'cfg(target_os = "windows")'.dependencies]
+cpal = {version = "0.13.1", features = ["asio"]}
+clang-sys = "0.29.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@ pub fn print_audio_system_tree() {
         print_host(host_id, default_host.id());
 
         if HOST_ENUMERATION_BLACKLIST.contains(&host_id.name()) {
-            println!("  Cannot enumerate {} devices.",
+            println!("  Skipping {} devices.",
                 host_id.name());
             continue;
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,17 +1,38 @@
 use cpal::traits::{HostTrait, DeviceTrait};
 
+// CPAL has a bug where it will panic if WASAPI devices are
+// enumerated after ASIO devices. Until this is fixed, we
+// simply refuse to enumerate WASAPI devices.
+// The issue is likely due to ASIO and CPAL's WASAPI
+// implementation initializing COM in the same thread using
+// incompatible threading models. For more infromation, see:
+//   https://github.com/RustAudio/cpal/issues/538
+//   https://github.com/RustAudio/cpal/pull/504
+//   https://github.com/RustAudio/cpal/pull/441
+const HOST_ENUMERATION_BLACKLIST: &'static [&'static str] = if cfg!(windows) {
+    &["WASAPI"]
+} else {
+    &[]
+};
+
 pub fn print_audio_system_tree() {
     let default_host = cpal::default_host();
 
     for host_id in cpal::available_hosts() {
         print_host(host_id, default_host.id());
 
+        if HOST_ENUMERATION_BLACKLIST.contains(&host_id.name()) {
+            println!("  Cannot enumerate {} devices.",
+                host_id.name());
+            continue;
+        }
+
         match cpal::host_from_id(host_id) {
             Ok(host)=> {
                 print_devices(host);
             },
             Err(e) => {
-                println!("The {:?} host is unvailable. {}", host_id, e);
+                println!("  The {:?} host is unvailable. {}", host_id, e);
             }
         }
     }
@@ -76,7 +97,7 @@ fn is_same_device(left: &cpal::Device, right: &cpal::Device) -> bool {
         if let Ok(right_device_name) = right.name() {
             return left_device_name == right_device_name;
         }
-    } 
+    }
     false
 }
 
@@ -90,7 +111,7 @@ fn label_for_device(device: &cpal::Device, host: &cpal::Host) -> String {
             }
         },
 
-        None => println!("No default input device is available for this host.")
+        None => println!("  No default input device is available for this host.")
     }
 
     match host.default_output_device() {
@@ -100,7 +121,7 @@ fn label_for_device(device: &cpal::Device, host: &cpal::Host) -> String {
             }
         },
 
-        None => println!("No default output device is available for this host.")
+        None => println!("  No default output device is available for this host.")
     }
 
     device_name_label


### PR DESCRIPTION
This PR adds support for building CPAL with ASIO support on Windows, and includes a workaround (hopefully a temporary one) where we "blacklist" WASAPI when enumerating its devices so that we avoid bugs in CPAL's WASAPI implementation. WASAPI is still supported, but its devices aren't listed when printing the audio system tree.