### PR TITLE
ci: Run cargo clippy

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -60,6 +60,11 @@ jobs:
         with:
           command: check
 
+      - name: cargo clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+
       - name: cargo test
         uses: actions-rs/cargo@v1
         with:


### PR DESCRIPTION
`cargo clippy` is a superset of `cargo check`.

```$ cargo clippy --help
Checks a package to catch common mistakes and improve your Rust code.
```
